### PR TITLE
调整macOS通用包打包方式及Outlook认证回调

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
           pip install --upgrade pip
           pip install pyinstaller
           pip install -r requirements.txt
-          pip uninstall cffi
+          pip uninstall -y cffi
           pip install --no-cache-dir --no-binary=:all: cffi
 
       - name: Build executable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         # macOS产物.app实际上是一个文件夹，需打包成一个文件，因后续release阶段仅支持上传单个文件
         run: |
           mkdir -p release/macos
-          ditto -c -k --sequesterRsrc --keepParent --preserveHFSCompression dist/RailTicket2Chepiaopiao.app ${{ env.APP_NAME }}-${{ env.VERSION }}.app.zip
+          ditto -c -k --sequesterRsrc --keepParent --preserveHFSCompression dist/RailTicket2Chepiaopiao.app release/macos/${{ env.APP_NAME }}-${{ env.VERSION }}.app.zip
         shell: bash
 
       - name: Upload artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,8 @@ jobs:
         # macOS产物.app实际上是一个文件夹，需打包成一个文件，因后续release阶段仅支持上传单个文件
         run: |
           mkdir -p release/macos
-          ditto -c -k --sequesterRsrc --keepParent --preserveHFSCompression dist/RailTicket2Chepiaopiao.app release/macos/${{ env.APP_NAME }}-${{ env.VERSION }}.app.zip
+          mv dist/RailTicket2Chepiaopiao.app dist/${{ env.APP_NAME }}-${{ env.VERSION }}.app
+          ditto -c -k --sequesterRsrc --keepParent --preserveHFSCompression dist/${{ env.APP_NAME }}-${{ env.VERSION }}.app release/macos/${{ env.APP_NAME }}-${{ env.VERSION }}.app.zip
         shell: bash
 
       - name: Upload artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,9 +84,10 @@ jobs:
           pyinstaller --onefile --windowed --name RailTicket2Chepiaopiao --target-arch universal2 main.py
 
       - name: Prepare artifacts
+        # macOS产物.app实际上是一个文件夹，需打包成一个文件，因后续release阶段仅支持上传单个文件
         run: |
           mkdir -p release/macos
-          mv dist/RailTicket2Chepiaopiao.app release/macos/${{ env.APP_NAME }}-${{ env.VERSION }}.app
+          ditto -c -k --sequesterRsrc --keepParent --preserveHFSCompression dist/RailTicket2Chepiaopiao.app ${{ env.APP_NAME }}-${{ env.VERSION }}.app.zip
         shell: bash
 
       - name: Upload artifact
@@ -159,6 +160,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: release/macos/${{ env.APP_NAME }}-${{ env.VERSION }}.app
-          asset_name: ${{ env.APP_NAME }}-${{ env.VERSION }}.app
-          asset_content_type: application/octet-stream
+          asset_path: release/macos/${{ env.APP_NAME }}-${{ env.VERSION }}.app.zip
+          asset_name: ${{ env.APP_NAME }}-${{ env.VERSION }}.app.zip
+          asset_content_type: application/zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ on:
   push:
     tags:
       - '*'
-  workflow_dispatch:  # 允许在 GitHub UI 里手动触发
 
 permissions:
   contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,40 +56,8 @@ jobs:
           name: ${{ runner.os }}-executable
           path: release/${{ runner.os == 'Windows' && 'windows' || 'linux' }}/
 
-  build_x86_64:
-    name: Build macOS x86_64 Binary
-    runs-on: macos-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install Rosetta 2
-        run: |
-          sudo softwareupdate --install-rosetta --agree-to-license || true
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.x'
-
-      - name: Install dependencies for x86_64
-        run: |
-          arch -x86_64 pip install --upgrade pip
-          arch -x86_64 pip install pyinstaller
-          arch -x86_64 pip install -r requirements.txt
-
-      - name: Build x86_64 executable
-        run: |
-          arch -x86_64 pyinstaller --windowed --name ${{ env.APP_NAME }}_macos_x86_64 main.py
-
-      - name: Upload x86_64 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos_x86_64_build
-          path: dist/${{ env.APP_NAME }}_macos_x86_64.app/**
-
-  build_arm64:
-    name: Build macOS arm64 Binary
+  build_macos:
+    name: Build macOS Universal2 Binary
     runs-on: macos-latest
     steps:
       - name: Checkout code
@@ -100,94 +68,36 @@ jobs:
         with:
           python-version: '3.x'
 
-      - name: Install dependencies for arm64
+      - name: Install dependencies
+        # 非源码安装的cffi库默认只支持当前设备架构
+        # 这里卸载cffi库，通过源码安装，以同时支持arm64 + x86_64架构
         run: |
           pip install --upgrade pip
           pip install pyinstaller
           pip install -r requirements.txt
+          pip uninstall cffi
+          pip install --no-cache-dir --no-binary=:all: cffi
 
-      - name: Build arm64 executable
+      - name: Build executable
         run: |
-          pyinstaller --windowed --name ${{ env.APP_NAME }}_macos_arm64 main.py
+          pyinstaller --onefile --windowed --target-arch universal2 main.py
 
-      - name: Upload arm64 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos_arm64_build
-          path: dist/${{ env.APP_NAME }}_macos_arm64.app/**
-
-  merge_binaries:
-    name: Merge macOS Binaries into Universal
-    runs-on: macos-latest
-    needs:
-      - build_x86_64
-      - build_arm64
-    steps:
-      - name: Download x86_64 artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: macos_x86_64_build
-          path: x86_64_build/${{ env.APP_NAME }}_macos_x86_64.app
-
-      - name: Download arm64 artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: macos_arm64_build
-          path: arm64_build/${{ env.APP_NAME }}_macos_arm64.app
-
-      - name: Merge executables using lipo
+      - name: Prepare artifacts
         run: |
           mkdir -p release/macos
-          # 复制 x86_64 应用程序作为基础
-          cp -R x86_64_build/${{ env.APP_NAME }}_macos_x86_64.app release/macos/${{ env.APP_NAME }}_macos_universal.app
-          # 将 arm64 可执行文件复制到应用程序包中
-          cp arm64_build/${{ env.APP_NAME }}_macos_arm64.app/Contents/MacOS/${{ env.APP_NAME }}_macos_arm64 \
-            release/macos/${{ env.APP_NAME }}_macos_universal.app/Contents/MacOS/
-          # 使用 lipo 合并二进制文件，生成通用可执行文件
-          lipo -create \
-            release/macos/${{ env.APP_NAME }}_macos_universal.app/Contents/MacOS/${{ env.APP_NAME }}_macos_x86_64 \
-            release/macos/${{ env.APP_NAME }}_macos_universal.app/Contents/MacOS/${{ env.APP_NAME }}_macos_arm64 \
-            -output release/macos/${{ env.APP_NAME }}_macos_universal.app/Contents/MacOS/${{ env.APP_NAME }}_macos_universal
-          # 更新 Info.plist 中的可执行文件名
-          /usr/libexec/PlistBuddy -c "Set :CFBundleExecutable ${{ env.APP_NAME }}_macos_universal" \
-            release/macos/${{ env.APP_NAME }}_macos_universal.app/Contents/Info.plist
-          # 删除架构特定的可执行文件
-          rm -f release/macos/${{ env.APP_NAME }}_macos_universal.app/Contents/MacOS/${{ env.APP_NAME }}_macos_x86_64
-          rm -f release/macos/${{ env.APP_NAME }}_macos_universal.app/Contents/MacOS/${{ env.APP_NAME }}_macos_arm64
-          find release/macos/${{ env.APP_NAME }}_macos_universal.app -type f -exec chmod +x {} \;
+          mv dist/main.app release/macos/${{ env.APP_NAME }}-${{ env.VERSION }}.app
+        shell: bash
 
-      - name: Upload universal binary artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: macos_universal_build
+          name: macOS-executable
           path: release/macos/
-
-  compress_macos_app:
-    name: Compress macOS app
-    runs-on: macos-latest
-    needs: merge_binaries
-    steps:
-      - name: Download macOS artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: macos_universal_build
-          path: release/macos
-
-      - name: Compress macOS app
-        run: |
-          cd release/macos
-          ditto -c -k --sequesterRsrc --keepParent --preserveHFSCompression ${{ env.APP_NAME }}_macos_universal.app ${{ env.APP_NAME }}-${{ env.VERSION }}.zip
-
-      - name: Upload macOS Release Asset
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos_compressed_build
-          path: release/macos/${{ env.APP_NAME }}-${{ env.VERSION }}.zip
 
   release:
     needs:
       - build_windows_linux
-      - compress_macos_app
+      - build_macos
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
@@ -208,7 +118,7 @@ jobs:
       - name: Download macOS artifact
         uses: actions/download-artifact@v4
         with:
-          name: macos_compressed_build
+          name: macOS-executable
           path: release/macos
 
       - name: Create GitHub Release
@@ -248,6 +158,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: release/macos/${{ env.APP_NAME }}-${{ env.VERSION }}.zip
-          asset_name: ${{ env.APP_NAME }}-${{ env.VERSION }}.zip
-          asset_content_type: application/zip
+          asset_path: release/macos/${{ env.APP_NAME }}-${{ env.VERSION }}.app
+          asset_name: ${{ env.APP_NAME }}-${{ env.VERSION }}.app
+          asset_content_type: application/octet-stream

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,12 +81,12 @@ jobs:
 
       - name: Build executable
         run: |
-          pyinstaller --onefile --windowed --target-arch universal2 main.py
+          pyinstaller --onefile --windowed --name RailTicket2Chepiaopiao --target-arch universal2 main.py
 
       - name: Prepare artifacts
         run: |
           mkdir -p release/macos
-          mv dist/main.app release/macos/${{ env.APP_NAME }}-${{ env.VERSION }}.app
+          mv dist/RailTicket2Chepiaopiao.app release/macos/${{ env.APP_NAME }}-${{ env.VERSION }}.app
         shell: bash
 
       - name: Upload artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ on:
   push:
     tags:
       - '*'
+  workflow_dispatch:  # 允许在 GitHub UI 里手动触发
 
 permissions:
   contents: write

--- a/main.py
+++ b/main.py
@@ -256,7 +256,7 @@ def fetch_outlook_emails_with_keyword(keyword="12306"):
         credential = InteractiveBrowserCredential(
             client_id=CLIENT_ID,
             tenant_id=TENANT_ID,
-            redirect_uri="http://localhost:8400"
+            redirect_uri="http://127.0.0.1:8400"
         )
         token = credential.get_token(*SCOPES).token
         safe_log_message("获取 Outlook 令牌成功，正在获取邮件...")


### PR DESCRIPTION
* 调整macOS通用包打包方式

    > 经测试Action运行正常，且产物在M芯片、Intel芯片Mac上均可运行

* 调整Outlook认证回调Uri，避免在macOS上无法启动HTTP Server

    > 使用localhost会报错：获取 Outlook 邮件时出错: Couldn't start an HTTP server on http://localhost:8400/
    > 改为127.0.0.1后还需要在微软后台把注册的回调地址改一下，否则浏览器中登录成功后回调会失败